### PR TITLE
Add CPU/GPU sensor options to preferences

### DIFF
--- a/Fanny/Fanny.xcodeproj/project.pbxproj
+++ b/Fanny/Fanny.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		375F0C14245A956F000C7D4D /* Sensor+FNYExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 375F0C13245A956F000C7D4D /* Sensor+FNYExtensions.swift */; };
 		8410EFB42336998D0003F94C /* Fan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8410EFB32336998D0003F94C /* Fan.swift */; };
 		8410EFB52336998D0003F94C /* Fan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8410EFB32336998D0003F94C /* Fan.swift */; };
 		8410EFB92336B5B50003F94C /* FNYLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8410EFB72336B5B50003F94C /* FNYLauncher.swift */; };
@@ -80,6 +81,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		375F0C13245A956F000C7D4D /* Sensor+FNYExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Sensor+FNYExtensions.swift"; sourceTree = "<group>"; };
 		8410EFB32336998D0003F94C /* Fan.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Fan.swift; path = smc/SMC/Fan.swift; sourceTree = "<group>"; };
 		8410EFB72336B5B50003F94C /* FNYLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FNYLauncher.swift; sourceTree = "<group>"; };
 		8410EFBB2336C4690003F94C /* FNYPreferencesWindow.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = FNYPreferencesWindow.storyboard; sourceTree = "<group>"; };
@@ -165,6 +167,7 @@
 				8410EFCA2336E4A00003F94C /* Temperature+FNYExtensions.swift */,
 				84620D852447C2F3003B7B91 /* String+FNYExtensions.swift */,
 				8410EFCD2336F1CE0003F94C /* Bundle+FNYExtensions.swift */,
+				375F0C13245A956F000C7D4D /* Sensor+FNYExtensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -458,6 +461,7 @@
 				8410EFB42336998D0003F94C /* Fan.swift in Sources */,
 				84C31D4E231D7C9A00B8A9D5 /* SMC+Extensions.swift in Sources */,
 				84E993F3232ECE5E009000FC /* FNYDelegateMulticast.swift in Sources */,
+				375F0C14245A956F000C7D4D /* Sensor+FNYExtensions.swift in Sources */,
 				8410EFCB2336E4A00003F94C /* Temperature+FNYExtensions.swift in Sources */,
 				84C31D4C231D7C9A00B8A9D5 /* SMCStructure.swift in Sources */,
 				84C31D51231D7C9A00B8A9D5 /* SMC+GPU.swift in Sources */,

--- a/Fanny/fanny-shared/Extensions/Sensor+FNYExtensions.swift
+++ b/Fanny/fanny-shared/Extensions/Sensor+FNYExtensions.swift
@@ -1,0 +1,39 @@
+//
+//  Sensor+FNYExtensions.swift
+//  Fanny
+//
+
+import Foundation
+
+extension SMC.Sensor.CPU {
+    static func title(for key: SensorKey) -> String {
+        switch key {
+        case core_01:   return "Core 1"
+        case core_02:   return "Core 2"
+        case core_03:   return "Core 3"
+        case core_04:   return "Core 4"
+        case core_05:   return "Core 5"
+        case core_06:   return "Core 6"
+        case core_07:   return "Core 7"
+        case core_08:   return "Core 8"
+        case die:       return "Die"
+        case diode:     return "Diode"
+        case heatsink:  return "Heat Sink"
+        case peci:      return "PECI"
+        case proximity: return "Proximity"
+        default:        return ""
+        }
+    }
+}
+
+extension SMC.Sensor.GPU {
+    static func title(for key: SensorKey) -> String {
+        switch key {
+        case diode:     return "Diode"
+        case heatsink:  return "Heat Sink"
+        case peci:      return "PECI"
+        case proximity: return "Proximity"
+        default:        return ""
+        }
+    }
+}

--- a/Fanny/fanny-shared/Extensions/Temperature+FNYExtensions.swift
+++ b/Fanny/fanny-shared/Extensions/Temperature+FNYExtensions.swift
@@ -25,5 +25,18 @@ extension Temperature {
             ? String(format: "%.0f\(temperatureUnitOption.suffix)", temperature.rounded())
             : String(format: "%.2f\(temperatureUnitOption.suffix)", temperature)
     }
-    
+
+    #if APP_EXTENSION
+        //
+    #else
+        static func cpu() -> Temperature? {
+            let cpuSensorOption = FNYUserPreferences.cpuSensorOption()
+            return cpuSensorOption.index == 0 ? SMC.shared.cpuTemperatureAverage() : SMC.shared.cpuTemperature(key: cpuSensorOption.key)
+        }
+
+        static func gpu() -> Temperature? {
+            let gpuSensorOption = FNYUserPreferences.gpuSensorOption()
+            return gpuSensorOption.index == 0 ? SMC.shared.gpuTemperatureAverage() : SMC.shared.gpuTemperature(key: gpuSensorOption.key)
+        }
+    #endif
 }

--- a/Fanny/fanny-shared/Monitor/FNYMonitor.swift
+++ b/Fanny/fanny-shared/Monitor/FNYMonitor.swift
@@ -63,8 +63,8 @@ class FNYMonitor {
             //
         #else
             let fans: [Fan] = SMC.shared.fans()
-            let cpuTemperature: Temperature? = SMC.shared.cpuTemperatureAverage()
-            let gpuTemperature: Temperature? = SMC.shared.gpuTemperatureAverage()
+            let cpuTemperature: Temperature? = .cpu()
+            let gpuTemperature: Temperature? = .gpu()
         
             updateLocalStorageSystemStats((fans: fans, cpuTemperature: cpuTemperature, gpuTemperature: gpuTemperature))
         #endif

--- a/Fanny/fanny-shared/Storage/FNYUserPreferences.swift
+++ b/Fanny/fanny-shared/Storage/FNYUserPreferences.swift
@@ -11,6 +11,8 @@ import Foundation
 typealias MonitorRefreshTimeIntervalOption = (index: Int, title: String, timeInterval: TimeInterval)
 typealias TemperatureUnitOption = (index: Int, title: String, suffix: String)
 typealias MenuBarIconOption = (index: Int, title: String)
+typealias CPUSensorOption = (index: Int, title: String, key: String)
+typealias GPUSensorOption = (index: Int, title: String, key: String)
 
 class FNYUserPreferences {
     
@@ -34,11 +36,25 @@ class FNYUserPreferences {
                 (1, "CPU Temperature"),
                 (2, "GPU Temperature")]
     }()
+
+    #if APP_EXTENSION
+        //
+    #else
+        static let cpuSensorOptions: [CPUSensorOption] = {
+            return [defaultCPUSensorOption] + SMC.Sensor.CPU.all.enumerated().map { ($0 + 1, SMC.Sensor.CPU.title(for: $1), $1) }
+        }()
+
+        static let gpuSensorOptions: [GPUSensorOption] = {
+            return [defaultGPUSensorOption] + SMC.Sensor.GPU.all.enumerated().map { ($0 + 1, SMC.Sensor.GPU.title(for: $1), $1) }
+        }()
+    #endif
     
     private static let defaultMonitorRefreshTimeIntervalOption: MonitorRefreshTimeIntervalOption = (0, "3 seconds", 3.0)
     private static let defaultTemperatureUnitOption: TemperatureUnitOption = (0, "Celsius (°C)", "°C")
     private static let defaultMenuBarIconOption: MenuBarIconOption = (0, "Fanny Icon")
-    
+    private static let defaultCPUSensorOption: CPUSensorOption = (0, "Average", "")
+    private static let defaultGPUSensorOption: GPUSensorOption = (0, "Average", "")
+
     private static let sharedDefaultsSuiteName: String = "fanny-shared-defaults"
     private static let sharedDefaults: UserDefaults = UserDefaults(suiteName: FNYUserPreferences.sharedDefaultsSuiteName)!
     
@@ -72,6 +88,29 @@ class FNYUserPreferences {
         return menuBarIconOptions.first(where: { $0.index == savedIndex }) ?? defaultMenuBarIconOption
     }
     
+    #if APP_EXTENSION
+        //
+    #else
+        // MARK: - CPU Sensor
+        static func save(cpuSensorOption: CPUSensorOption) {
+            sharedDefaults.set(cpuSensorOption.key, forKey: FNYUserPreferencesKey.cpuSensorOption.stringValue)
+        }
+
+        static func cpuSensorOption() -> CPUSensorOption {
+            let savedKey: String? = sharedDefaults.string(forKey: FNYUserPreferencesKey.cpuSensorOption.stringValue)
+            return cpuSensorOptions.first(where: { $0.key == savedKey }) ?? defaultCPUSensorOption
+        }
+
+        // MARK: - GPU Sensor
+        static func save(gpuSensorOption: GPUSensorOption) {
+            sharedDefaults.set(gpuSensorOption.key, forKey: FNYUserPreferencesKey.gpuSensorOption.stringValue)
+        }
+
+        static func gpuSensorOption() -> GPUSensorOption {
+            let savedKey: String? = sharedDefaults.string(forKey: FNYUserPreferencesKey.gpuSensorOption.stringValue)
+            return gpuSensorOptions.first(where: { $0.key == savedKey }) ?? defaultGPUSensorOption
+        }
+    #endif
 }
 
 // MARK: - FNYUserPreferencesKey
@@ -80,12 +119,16 @@ private enum FNYUserPreferencesKey {
     case monitorRefreshTimeIntervalOption
     case temperatureUnitOption
     case menuBarIconOption
+    case cpuSensorOption
+    case gpuSensorOption
     
     var stringValue: String {
         switch self {
         case .monitorRefreshTimeIntervalOption: return "FNYUserPreferencesKey_MonitorRefreshTimeIntervalOption"
         case .temperatureUnitOption: return "FNYUserPreferencesKey_TemperatureUnitOption"
         case .menuBarIconOption: return "FNYUserPreferencesKey_MenuBarIconOption"
+        case .cpuSensorOption: return "FNYUserPreferencesKey_CPUSensorOption"
+        case .gpuSensorOption: return "FNYUserPreferencesKey_GPUSensorOption"
         }
     }
     

--- a/Fanny/fanny/Menu/FNYMenuController.swift
+++ b/Fanny/fanny/Menu/FNYMenuController.swift
@@ -39,8 +39,8 @@ class FNYMenuController {
         var title: String?
         
         switch FNYUserPreferences.menuBarIconOption().index {
-        case 1: title = SMC.shared.cpuTemperatureAverage()?.formattedTemperature(rounded: true)
-        case 2: title = SMC.shared.gpuTemperatureAverage()?.formattedTemperature(rounded: true)
+        case 1: title = Temperature.cpu()?.formattedTemperature(rounded: true)
+        case 2: title = Temperature.gpu()?.formattedTemperature(rounded: true)
         default: image = NSImage(named: "status-item-icon-default.png")
         }
         
@@ -50,8 +50,8 @@ class FNYMenuController {
     // MARK: - Update Menu Items
     @objc private func updateMenuItems() {
         let items: [NSMenuItem] = menuItems(fans: SMC.shared.fans(),
-                                            cpuTemperature: SMC.shared.cpuTemperatureAverage(),
-                                            gpuTemperature: SMC.shared.gpuTemperatureAverage())
+                                            cpuTemperature: .cpu(),
+                                            gpuTemperature: .gpu())
         
         guard !items.isEmpty else { return }
         if #available(OSX 10.14, *) {
@@ -69,8 +69,8 @@ class FNYMenuController {
     private func updateMenuToolTip() {
         guard
             let toolTip: String = menuToolTip(fans: SMC.shared.fans(),
-                                              cpuTemperature: SMC.shared.cpuTemperatureAverage(),
-                                              gpuTemperature: SMC.shared.gpuTemperatureAverage())
+                                              cpuTemperature: .cpu(),
+                                              gpuTemperature: .gpu())
             else { return }
         
         statusBar.updateStatusItem(toolTip: toolTip)

--- a/Fanny/fanny/Preferences/FNYPreferencesViewController.swift
+++ b/Fanny/fanny/Preferences/FNYPreferencesViewController.swift
@@ -13,7 +13,9 @@ class FNYPreferencesViewController: NSViewController {
     @IBOutlet private weak var monitorRefreshTimeIntervalPopUpButton: NSPopUpButton!
     @IBOutlet private weak var temperatureUnitPopUpButton: NSPopUpButton!
     @IBOutlet private weak var menuBarIconPopUpButton: NSPopUpButton!
-    
+    @IBOutlet private weak var cpuSensorPopUpButton: NSPopUpButton!
+    @IBOutlet private weak var gpuSensorPopUpButton: NSPopUpButton!
+
     @IBOutlet private weak var gitHubButton: NSButton!
     @IBOutlet private weak var versionTextField: FNYTextField! {
         didSet { versionTextField.stringValue = "v\(Bundle.appVersion)" }
@@ -31,6 +33,8 @@ class FNYPreferencesViewController: NSViewController {
         prepareMonitorRefreshTimeIntervalPopUpButton()
         prepareTemperatureUnitPopUpButton()
         prepareIconPopUpButton()
+        prepareCPUSensorPopUpButton()
+        prepareGPUSensorPopUpButton()
     }
     
     // MARK: - Setup
@@ -50,6 +54,18 @@ class FNYPreferencesViewController: NSViewController {
         menuBarIconPopUpButton.removeAllItems()
         menuBarIconPopUpButton.addItems(withTitles: FNYUserPreferences.menuBarIconOptions.map({ $0.title }))
         menuBarIconPopUpButton.selectItem(at: FNYUserPreferences.menuBarIconOption().index)
+    }
+
+    private func prepareCPUSensorPopUpButton() {
+        cpuSensorPopUpButton.removeAllItems()
+        cpuSensorPopUpButton.addItems(withTitles: FNYUserPreferences.cpuSensorOptions.map({ $0.title }))
+        cpuSensorPopUpButton.selectItem(at: FNYUserPreferences.cpuSensorOption().index)
+    }
+
+    private func prepareGPUSensorPopUpButton() {
+        gpuSensorPopUpButton.removeAllItems()
+        gpuSensorPopUpButton.addItems(withTitles: FNYUserPreferences.gpuSensorOptions.map({ $0.title }))
+        gpuSensorPopUpButton.selectItem(at: FNYUserPreferences.gpuSensorOption().index)
     }
     
     // MARK: - Preference Actions
@@ -72,6 +88,20 @@ class FNYPreferencesViewController: NSViewController {
         let selectedIndex: Int = sender.indexOfSelectedItem
         guard let selectedMenuBarIconIconOption: MenuBarIconOption = FNYUserPreferences.menuBarIconOptions.first(where: { $0.index == selectedIndex }) else { return }
         FNYUserPreferences.save(menuBarIconOption: selectedMenuBarIconIconOption)
+        FNYMonitor.shared.refreshSystemStats()
+    }
+
+    @IBAction private func cpuSensorPopUpButtonOptionClicked(_ sender: NSPopUpButton) {
+        let selectedIndex: Int = sender.indexOfSelectedItem
+        guard let selectedCPUSensorOption: CPUSensorOption = FNYUserPreferences.cpuSensorOptions.first(where: { $0.index == selectedIndex }) else { return }
+        FNYUserPreferences.save(cpuSensorOption: selectedCPUSensorOption)
+        FNYMonitor.shared.refreshSystemStats()
+    }
+
+    @IBAction private func gpuSensorPopUpButtonOptionClicked(_ sender: NSPopUpButton) {
+        let selectedIndex: Int = sender.indexOfSelectedItem
+        guard let selectedGPUSensorOption: GPUSensorOption = FNYUserPreferences.gpuSensorOptions.first(where: { $0.index == selectedIndex }) else { return }
+        FNYUserPreferences.save(gpuSensorOption: selectedGPUSensorOption)
         FNYMonitor.shared.refreshSystemStats()
     }
     

--- a/Fanny/fanny/Preferences/FNYPreferencesWindow.storyboard
+++ b/Fanny/fanny/Preferences/FNYPreferencesWindow.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="3er-qC-rPb">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="3er-qC-rPb">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16096"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15705"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -31,11 +31,11 @@
             <objects>
                 <viewController id="f7D-mS-rfl" customClass="FNYPreferencesViewController" customModule="Fanny" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="FFZ-n6-WSA">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="216"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="298"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PCL-rq-w1N" customClass="FNYTextField" customModule="Fanny" customModuleProvider="target">
-                                <rect key="frame" x="18" y="178" width="164" height="16"/>
+                                <rect key="frame" x="18" y="260" width="164" height="16"/>
                                 <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" refusesFirstResponder="YES" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="Refresh Interval:" id="RUC-3C-QPd">
                                     <font key="font" usesAppearanceFont="YES"/>
                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -43,13 +43,13 @@
                                 </textFieldCell>
                             </textField>
                             <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="XMA-MT-qTf">
-                                <rect key="frame" x="186" y="172" width="117" height="25"/>
+                                <rect key="frame" x="186" y="254" width="117" height="25"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" priority="750" constant="112" id="4OT-M0-pXm"/>
                                 </constraints>
                                 <popUpButtonCell key="cell" type="push" title="3 Seconds" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="FBm-rj-RP0" id="6XD-I3-epj">
                                     <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                                    <font key="font" metaFont="system"/>
+                                    <font key="font" metaFont="menu"/>
                                     <menu key="menu" id="ME8-bX-ktw">
                                         <items>
                                             <menuItem title="3 Seconds" state="on" id="FBm-rj-RP0">
@@ -63,7 +63,7 @@
                                 </connections>
                             </popUpButton>
                             <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9MU-ci-1bf" customClass="FNYTextField" customModule="Fanny" customModuleProvider="target">
-                                <rect key="frame" x="18" y="137" width="164" height="16"/>
+                                <rect key="frame" x="18" y="219" width="164" height="16"/>
                                 <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" refusesFirstResponder="YES" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="Temperature Unit:" id="Epb-B2-ugL">
                                     <font key="font" usesAppearanceFont="YES"/>
                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -71,13 +71,13 @@
                                 </textFieldCell>
                             </textField>
                             <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="qPJ-Ta-jTg">
-                                <rect key="frame" x="186" y="131" width="117" height="25"/>
+                                <rect key="frame" x="186" y="213" width="117" height="25"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" priority="750" constant="112" id="RxV-TR-LzR"/>
                                 </constraints>
                                 <popUpButtonCell key="cell" type="push" title="Celsius (°C)" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="9jW-RZ-YJi" id="GOw-Ce-2dm">
                                     <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                                    <font key="font" metaFont="system"/>
+                                    <font key="font" metaFont="menu"/>
                                     <menu key="menu" id="c0J-uF-Kk8">
                                         <items>
                                             <menuItem title="Celsius (°C)" state="on" id="9jW-RZ-YJi"/>
@@ -89,7 +89,7 @@
                                 </connections>
                             </popUpButton>
                             <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8AR-fW-ZTI" customClass="FNYTextField" customModule="Fanny" customModuleProvider="target">
-                                <rect key="frame" x="18" y="96" width="164" height="16"/>
+                                <rect key="frame" x="18" y="178" width="164" height="16"/>
                                 <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" refusesFirstResponder="YES" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="Menu Bar:" id="KY8-f0-z57">
                                     <font key="font" usesAppearanceFont="YES"/>
                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -97,13 +97,13 @@
                                 </textFieldCell>
                             </textField>
                             <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="EBX-fS-L8a">
-                                <rect key="frame" x="186" y="90" width="117" height="25"/>
+                                <rect key="frame" x="186" y="172" width="117" height="25"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" priority="750" constant="112" id="7sZ-rO-QUm"/>
                                 </constraints>
                                 <popUpButtonCell key="cell" type="push" title="Fanny Icon" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="aa9-Bg-8bx" id="qlR-25-V4m">
                                     <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                                    <font key="font" metaFont="system"/>
+                                    <font key="font" metaFont="menu"/>
                                     <menu key="menu" id="fgO-yf-kk4">
                                         <items>
                                             <menuItem title="Fanny Icon" state="on" id="aa9-Bg-8bx"/>
@@ -112,6 +112,58 @@
                                 </popUpButtonCell>
                                 <connections>
                                     <action selector="menuBarIconPopUpButtonOptionClicked:" target="f7D-mS-rfl" id="4gk-Cx-hTf"/>
+                                </connections>
+                            </popUpButton>
+                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eI2-Ox-Kq9" customClass="FNYTextField" customModule="Fanny" customModuleProvider="target">
+                                <rect key="frame" x="18" y="137" width="164" height="16"/>
+                                <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" refusesFirstResponder="YES" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="CPU Sensor:" id="Fmt-yg-5Ai">
+                                    <font key="font" usesAppearanceFont="YES"/>
+                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3mt-sa-IXy" userLabel="CPU Sensor Pop Up Button">
+                                <rect key="frame" x="186" y="131" width="117" height="25"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" priority="750" constant="112" id="y8N-Bw-pOn"/>
+                                </constraints>
+                                <popUpButtonCell key="cell" type="push" title="Average" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="cJU-tL-E84" id="p73-84-LWX">
+                                    <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="menu"/>
+                                    <menu key="menu" id="big-ff-00I">
+                                        <items>
+                                            <menuItem title="Average" state="on" id="cJU-tL-E84"/>
+                                        </items>
+                                    </menu>
+                                </popUpButtonCell>
+                                <connections>
+                                    <action selector="cpuSensorPopUpButtonOptionClicked:" target="f7D-mS-rfl" id="0fD-nS-djl"/>
+                                </connections>
+                            </popUpButton>
+                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4IV-gt-hml" customClass="FNYTextField" customModule="Fanny" customModuleProvider="target">
+                                <rect key="frame" x="18" y="96" width="164" height="16"/>
+                                <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" refusesFirstResponder="YES" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="GPU Sensor:" id="9va-iC-LKP">
+                                    <font key="font" usesAppearanceFont="YES"/>
+                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="kxZ-J4-v7Y" userLabel="GPU Sensor Pop Up Button">
+                                <rect key="frame" x="186" y="90" width="117" height="25"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" priority="750" constant="112" id="968-4J-gBD"/>
+                                </constraints>
+                                <popUpButtonCell key="cell" type="push" title="Average" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="d6U-gi-NWT" id="qIW-vu-97H">
+                                    <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="menu"/>
+                                    <menu key="menu" id="xmI-Le-sL9">
+                                        <items>
+                                            <menuItem title="Average" state="on" id="d6U-gi-NWT"/>
+                                        </items>
+                                    </menu>
+                                </popUpButtonCell>
+                                <connections>
+                                    <action selector="gpuSensorPopUpButtonOptionClicked:" target="f7D-mS-rfl" id="9Q7-Eb-ElI"/>
                                 </connections>
                             </popUpButton>
                             <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="Nk5-0r-rVv">
@@ -144,23 +196,32 @@
                             </textField>
                         </subviews>
                         <constraints>
+                            <constraint firstItem="3mt-sa-IXy" firstAttribute="centerY" secondItem="eI2-Ox-Kq9" secondAttribute="centerY" id="02L-eo-d2o"/>
                             <constraint firstItem="Nk5-0r-rVv" firstAttribute="leading" secondItem="FFZ-n6-WSA" secondAttribute="leading" constant="20" id="0yp-14-IYO"/>
                             <constraint firstItem="UnS-gL-Ld2" firstAttribute="top" secondItem="SH4-BH-lnm" secondAttribute="bottom" constant="8" id="4sf-ZV-bYc"/>
+                            <constraint firstItem="kxZ-J4-v7Y" firstAttribute="top" secondItem="3mt-sa-IXy" secondAttribute="bottom" constant="20" id="6E9-Nq-4gT"/>
+                            <constraint firstItem="4IV-gt-hml" firstAttribute="leading" secondItem="FFZ-n6-WSA" secondAttribute="leading" constant="20" id="7GU-dR-VgU"/>
                             <constraint firstItem="qPJ-Ta-jTg" firstAttribute="leading" secondItem="9MU-ci-1bf" secondAttribute="trailing" constant="8" id="8df-hq-uKq"/>
                             <constraint firstItem="UnS-gL-Ld2" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="FFZ-n6-WSA" secondAttribute="leading" constant="20" id="BEz-S7-hcq"/>
                             <constraint firstItem="XMA-MT-qTf" firstAttribute="top" secondItem="FFZ-n6-WSA" secondAttribute="top" constant="20" id="EOK-CX-GuV"/>
                             <constraint firstItem="EBX-fS-L8a" firstAttribute="width" secondItem="XMA-MT-qTf" secondAttribute="width" id="EVI-ly-0bc"/>
                             <constraint firstAttribute="trailing" secondItem="XMA-MT-qTf" secondAttribute="trailing" constant="20" id="EWY-8d-pAV"/>
+                            <constraint firstItem="3mt-sa-IXy" firstAttribute="width" secondItem="XMA-MT-qTf" secondAttribute="width" id="FLC-6e-UEE"/>
                             <constraint firstItem="EBX-fS-L8a" firstAttribute="centerY" secondItem="8AR-fW-ZTI" secondAttribute="centerY" id="GlF-Hq-9GU"/>
                             <constraint firstItem="qPJ-Ta-jTg" firstAttribute="width" secondItem="XMA-MT-qTf" secondAttribute="width" id="J0j-zp-OUj"/>
                             <constraint firstItem="SH4-BH-lnm" firstAttribute="top" secondItem="Nk5-0r-rVv" secondAttribute="bottom" constant="8" id="K8v-ZK-byW"/>
                             <constraint firstItem="XMA-MT-qTf" firstAttribute="centerY" secondItem="PCL-rq-w1N" secondAttribute="centerY" id="Mqn-JA-TuR"/>
                             <constraint firstItem="qPJ-Ta-jTg" firstAttribute="centerY" secondItem="9MU-ci-1bf" secondAttribute="centerY" id="OyP-Jm-BzB"/>
+                            <constraint firstAttribute="trailing" secondItem="kxZ-J4-v7Y" secondAttribute="trailing" constant="20" id="PxS-uA-acT"/>
                             <constraint firstItem="UnS-gL-Ld2" firstAttribute="centerX" secondItem="FFZ-n6-WSA" secondAttribute="centerX" id="Q85-ta-inS"/>
                             <constraint firstItem="SH4-BH-lnm" firstAttribute="centerX" secondItem="FFZ-n6-WSA" secondAttribute="centerX" id="QDK-L0-ESp"/>
+                            <constraint firstItem="3mt-sa-IXy" firstAttribute="top" secondItem="EBX-fS-L8a" secondAttribute="bottom" constant="20" id="QIC-2S-5t5"/>
                             <constraint firstItem="8AR-fW-ZTI" firstAttribute="leading" secondItem="FFZ-n6-WSA" secondAttribute="leading" constant="20" id="S3a-UK-gmv"/>
-                            <constraint firstItem="Nk5-0r-rVv" firstAttribute="top" secondItem="EBX-fS-L8a" secondAttribute="bottom" constant="20" id="WTD-ze-H4D"/>
+                            <constraint firstItem="eI2-Ox-Kq9" firstAttribute="leading" secondItem="FFZ-n6-WSA" secondAttribute="leading" constant="20" id="TCe-2o-8yF"/>
+                            <constraint firstItem="Nk5-0r-rVv" firstAttribute="top" secondItem="kxZ-J4-v7Y" secondAttribute="bottom" constant="20" id="WTD-ze-H4D"/>
+                            <constraint firstItem="kxZ-J4-v7Y" firstAttribute="centerY" secondItem="4IV-gt-hml" secondAttribute="centerY" id="ZoI-6Z-Mrv"/>
                             <constraint firstItem="EBX-fS-L8a" firstAttribute="top" secondItem="qPJ-Ta-jTg" secondAttribute="bottom" constant="20" id="a8D-hJ-QgR"/>
+                            <constraint firstItem="XMA-MT-qTf" firstAttribute="width" secondItem="kxZ-J4-v7Y" secondAttribute="width" id="aZ0-R9-Mb6"/>
                             <constraint firstItem="EBX-fS-L8a" firstAttribute="leading" secondItem="8AR-fW-ZTI" secondAttribute="trailing" constant="8" id="atu-tr-eqT"/>
                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="UnS-gL-Ld2" secondAttribute="trailing" constant="20" id="cHc-2b-gUn"/>
                             <constraint firstItem="Nk5-0r-rVv" firstAttribute="centerX" secondItem="FFZ-n6-WSA" secondAttribute="centerX" id="cbH-X3-5Z7"/>
@@ -168,14 +229,19 @@
                             <constraint firstItem="PCL-rq-w1N" firstAttribute="leading" secondItem="FFZ-n6-WSA" secondAttribute="leading" constant="20" id="f2P-ge-3E1"/>
                             <constraint firstItem="XMA-MT-qTf" firstAttribute="leading" secondItem="PCL-rq-w1N" secondAttribute="trailing" constant="8" id="j33-Xy-wq4"/>
                             <constraint firstAttribute="bottom" secondItem="UnS-gL-Ld2" secondAttribute="bottom" constant="8" id="kL7-Oz-8zT"/>
+                            <constraint firstItem="3mt-sa-IXy" firstAttribute="leading" secondItem="eI2-Ox-Kq9" secondAttribute="trailing" constant="8" id="lar-EN-BKf"/>
                             <constraint firstItem="9MU-ci-1bf" firstAttribute="leading" secondItem="FFZ-n6-WSA" secondAttribute="leading" constant="20" id="ogA-ho-GOQ"/>
+                            <constraint firstItem="kxZ-J4-v7Y" firstAttribute="leading" secondItem="4IV-gt-hml" secondAttribute="trailing" constant="8" id="omG-y4-Ir7"/>
+                            <constraint firstAttribute="trailing" secondItem="3mt-sa-IXy" secondAttribute="trailing" constant="20" id="shh-jT-sXB"/>
                             <constraint firstAttribute="trailing" secondItem="Nk5-0r-rVv" secondAttribute="trailing" constant="20" id="tdS-94-Sdy"/>
                             <constraint firstAttribute="trailing" secondItem="EBX-fS-L8a" secondAttribute="trailing" constant="20" id="vck-wO-YFV"/>
                             <constraint firstAttribute="trailing" secondItem="qPJ-Ta-jTg" secondAttribute="trailing" constant="20" id="wxK-OE-YGb"/>
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="cpuSensorPopUpButton" destination="3mt-sa-IXy" id="dQN-zm-u5n"/>
                         <outlet property="gitHubButton" destination="SH4-BH-lnm" id="onC-JC-iWi"/>
+                        <outlet property="gpuSensorPopUpButton" destination="kxZ-J4-v7Y" id="Uz1-Vs-5Eg"/>
                         <outlet property="menuBarIconPopUpButton" destination="EBX-fS-L8a" id="Hb6-u3-asv"/>
                         <outlet property="monitorRefreshTimeIntervalPopUpButton" destination="XMA-MT-qTf" id="ruL-od-fUK"/>
                         <outlet property="temperatureUnitPopUpButton" destination="qPJ-Ta-jTg" id="jCg-N6-lEk"/>


### PR DESCRIPTION
Addressing #45, this PR adds two new dropdowns to the preferences window:

![Screen Shot 2020-04-30 at 12 12 54](https://user-images.githubusercontent.com/2329661/80749862-fa4c5980-8adb-11ea-8fbd-27f94398be3c.png)

I opted to allow the user to select any sensor (even if the device doesn't have it), but this could be changed to only show those that report `celsius > 1.0`.
