### PR TITLE
Add option to display fastest spinning fan RPM on menu bar

### DIFF
--- a/Fanny/Fanny.xcodeproj/project.pbxproj
+++ b/Fanny/Fanny.xcodeproj/project.pbxproj
@@ -54,6 +54,8 @@
 		84E99404232EEB3D009000FC /* Global.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E99403232EEB3D009000FC /* Global.swift */; };
 		84E99405232EEB55009000FC /* Global.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E99403232EEB3D009000FC /* Global.swift */; };
 		84E99410232EF25A009000FC /* FNYRadioButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E9940F232EF25A009000FC /* FNYRadioButton.swift */; };
+		CF697FC62CB2DDAE000A4D5B /* Fan+FNYExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF697FC52CB2DDAE000A4D5B /* Fan+FNYExtensions.swift */; };
+		CF697FC72CB2DDAE000A4D5B /* Fan+FNYExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF697FC52CB2DDAE000A4D5B /* Fan+FNYExtensions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -122,6 +124,7 @@
 		84E99408232EEC88009000FC /* FNYWidgetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FNYWidgetViewController.swift; sourceTree = "<group>"; };
 		84E9940A232EEF7F009000FC /* FNYTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FNYTextField.swift; sourceTree = "<group>"; };
 		84E9940F232EF25A009000FC /* FNYRadioButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FNYRadioButton.swift; sourceTree = "<group>"; };
+		CF697FC52CB2DDAE000A4D5B /* Fan+FNYExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Fan+FNYExtensions.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -166,6 +169,7 @@
 				8410EFCA2336E4A00003F94C /* Temperature+FNYExtensions.swift */,
 				84620D852447C2F3003B7B91 /* String+FNYExtensions.swift */,
 				8410EFCD2336F1CE0003F94C /* Bundle+FNYExtensions.swift */,
+				CF697FC52CB2DDAE000A4D5B /* Fan+FNYExtensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -460,6 +464,7 @@
 				84C31D4E231D7C9A00B8A9D5 /* SMC+Extensions.swift in Sources */,
 				84E993F3232ECE5E009000FC /* FNYDelegateMulticast.swift in Sources */,
 				8410EFCB2336E4A00003F94C /* Temperature+FNYExtensions.swift in Sources */,
+				CF697FC62CB2DDAE000A4D5B /* Fan+FNYExtensions.swift in Sources */,
 				84C31D4C231D7C9A00B8A9D5 /* SMCStructure.swift in Sources */,
 				84C31D51231D7C9A00B8A9D5 /* SMC+GPU.swift in Sources */,
 				84C31D4F231D7C9A00B8A9D5 /* SMC+CPU.swift in Sources */,
@@ -501,6 +506,7 @@
 				84E99402232EE709009000FC /* FNYDelegateMulticast.swift in Sources */,
 				844F4E24245DDA96002D6DC4 /* Sensor.swift in Sources */,
 				84E99405232EEB55009000FC /* Global.swift in Sources */,
+				CF697FC72CB2DDAE000A4D5B /* Fan+FNYExtensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Fanny/fanny-shared/Extensions/Fan+FNYExtensions.swift
+++ b/Fanny/fanny-shared/Extensions/Fan+FNYExtensions.swift
@@ -1,0 +1,23 @@
+//
+//  Fan+FNYExtensions.swift
+//  Fanny
+//
+//  Created by Jorge Pastor on 06/10/2024.
+//  Copyright © 2024 Daniel Storm. All rights reserved.
+//
+
+import Foundation
+
+extension Array where Element == Fan {
+    
+    func fastest() -> Fan? {
+        return self.max(by: { (a, b) -> Bool in a.currentRPM ?? 0 < b.currentRPM ?? 0 })
+    }
+}
+
+extension Fan {
+    
+    func formattedRPM() -> String {
+        return (currentRPM?.description ?? "?") + " RPM"
+    }
+}

--- a/Fanny/fanny-shared/Storage/FNYUserPreferences.swift
+++ b/Fanny/fanny-shared/Storage/FNYUserPreferences.swift
@@ -13,6 +13,7 @@ typealias TemperatureUnitOption = (index: Int, title: String, suffix: String)
 typealias MenuBarIconOption = (index: Int, title: String)
 typealias CPUSensorOption = (index: Int, title: String, key: String?)
 typealias GPUSensorOption = (index: Int, title: String, key: String?)
+typealias FanSensorOption = (index: Int, title: String, key: String?)
 
 class FNYUserPreferences {
     
@@ -34,7 +35,8 @@ class FNYUserPreferences {
     static let menuBarIconOptions: [MenuBarIconOption] = {
         return [defaultMenuBarIconOption,
                 (1, "CPU Temperature"),
-                (2, "GPU Temperature")]
+                (2, "GPU Temperature"),
+                (3, "Fastest Fan RPM")]
     }()
 
     static let cpuSensorOptions: [CPUSensorOption] = {

--- a/Fanny/fanny/Menu/FNYMenuController.swift
+++ b/Fanny/fanny/Menu/FNYMenuController.swift
@@ -41,6 +41,7 @@ class FNYMenuController {
         switch FNYUserPreferences.menuBarIconOption().index {
         case 1: title = FNYLocalStorage.cpuTemperature()?.formattedTemperature(rounded: true)
         case 2: title = FNYLocalStorage.gpuTemperature()?.formattedTemperature(rounded: true)
+        case 3: title = FNYLocalStorage.fans().fastest()?.formattedRPM()
         default: image = NSImage(named: "status-item-icon-default.png")
         }
         


### PR DESCRIPTION
Tested on macOS Sonoma 14.7.

<img width="560" alt="Screenshot 2024-10-07 at 00 08 59" src="https://github.com/user-attachments/assets/eb223cdc-2f71-4e5b-a470-91a858e559a9">

